### PR TITLE
Avoid loops on Nomad jobs when downloading images if connection is very slow

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -110,6 +110,10 @@ sudo iptables -t nat -A PREROUTING -p tcp -m tcp --dport 53 -j REDIRECT --to-por
 sudo iptables -t nat -A OUTPUT -d localhost -p udp -m udp --dport 53 -j REDIRECT --to-ports 8600
 sudo iptables -t nat -A OUTPUT -d localhost -p tcp -m tcp --dport 53 -j REDIRECT --to-ports 8600
 
+echo "Pulling Docker images"
+
+find /vagrant/jobs/*.hcl -maxdepth 0 | xargs grep -E 'image\s*=\s*' | awk '{print $NF}' | sed -e 's/"//g' | xargs -L 1 sudo docker pull
+
 echo "Installing Grafana stack..."
 
 until nomad status


### PR DESCRIPTION
I sometimes happened to have a very bad connection (Edge/2g, yes this can really happen ;-) ) and in this
case the Nomad jobs keep retrying to download the image because  they can not succeed doing so before
retrial is triggered
One way to prevent this to happen is by downloading the Docker images within the Vagrant VM
prior to create the nomad jobs, therefore this patch