### PR TITLE
Improve regex for matching Nomad Allocation ids

### DIFF
--- a/jobs/prometheus.nomad.hcl
+++ b/jobs/prometheus.nomad.hcl
@@ -37,7 +37,7 @@ scrape_configs:
         regex: (.*)
         replacement: '$1'
       - source_labels: [__meta_consul_service_id]
-        regex: '_nomad-task-(.*)-(.*)-(.*)-(.*)'
+        regex: '_nomad-task-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})-.*'
         target_label:  'task_id'
         replacement: '$1'
       - source_labels: [__meta_consul_tags]

--- a/jobs/promtail.nomad.hcl
+++ b/jobs/promtail.nomad.hcl
@@ -47,7 +47,7 @@ scrape_configs:
       regex: (.*)
       replacement: '$1'
     - source_labels: [__meta_consul_service_id]
-      regex: '_nomad-task-(.*)-(.*)-(.*)-(.*)'
+      regex: '_nomad-task-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})-.*'
       target_label:  'task_id'
       replacement: '$1'
     - source_labels: [__meta_consul_tags]
@@ -61,7 +61,7 @@ scrape_configs:
       target_label:  'instance'
       replacement:   '$1'
     - source_labels: [__meta_consul_service_id]
-      regex: '_nomad-task-(.*)-(.*)-(.*)-(.*)'
+      regex: '_nomad-task-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})-.*'
       target_label:  '__path__'
       replacement: '/nomad/alloc/$1/alloc/logs/*std*.{?,??}'
 EOTC


### PR DESCRIPTION
This fixes and issue were Nomad tasks with `-` in their name wont match this regex and logs wont be picked up.

Nomad's Allocation IDS are [UUIDs](https://en.wikipedia.org/wiki/Universally_unique_identifier#Format), This regex matches for that pattern.